### PR TITLE
Add support for HomePatrol-2 by handling subfirmware version.

### DIFF
--- a/defs.py
+++ b/defs.py
@@ -1,8 +1,8 @@
 VERSION = '0.9.7.1'
 PROGRAM = 'HPe-rc'
-DESCRIPTION = 'HPe-rc is a utility program for controlling the Uniden HomePatrol-1 Scanner.'
+DESCRIPTION = 'HPe-rc is a utility program for controlling the Uniden HomePatrol-1 and HomePatrol-2 Scanners.'
 UPDATE_CHECK = 'http://update.hp.xoynq.com/'
-SUPPORTED_SCANNERS = ['HomePatrol-1']
+SUPPORTED_SCANNERS = ['HomePatrol-1', 'HomePatrol-2']
 
 OTHER = {
     '0' : 'None',

--- a/hpe-rc.py
+++ b/hpe-rc.py
@@ -1105,7 +1105,10 @@ def HP_open(port1, port2):
             ser1=None
         if ser1:
             try:
-                firmware,database,help=HP_version(ser1)
+                hasSubfirmwareVersion=False
+                if model=='HomePatrol-2':
+                    hasSubfirmwareVersion=True
+                firmware,database,help=HP_version(ser1, hasSubfirmwareVersion)
                 logging.debug(' '.join(['Version:',firmware,'HPDB:',database,'HELP:',help]))
                 config['hp_firmware']=firmware
                 config['hp_database']=database
@@ -1404,12 +1407,15 @@ def HP_model(ser):
         return rs[2]
     return 'None'
 
-def HP_version(ser):
+def HP_version(ser, hasSubfirmwareVersion=False):
     logging.debug('CMD : Get Version')
     ser.write(command('RMT','VERSION'))
     rs = r2r(ser)
     if not checkerr(rs):
-        return rs[2],rs[3],rs[4]
+        if hasSubfirmwareVersion:
+            return rs[2],rs[4],rs[5]
+        else:
+            return rs[2],rs[3],rs[4]
     return '','',''
 
 def HP_status(ser, display=True):


### PR DESCRIPTION
This proposed commit adds support for the HomePatrol-2 by handling the fact that the VERSION command returns and extra field for the "subfirmware" version. After handling this change, all features of HPe-rc appear to work.

I do not own an HP-1, so I could not confirm that HP-1 support is no regressed in any way. The risk of this is low and can be confirmed by a simple smoke test.